### PR TITLE
Support uploading bundle from staged s3 bucket to DSS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,21 @@
 language: python
 cache: pip
-
 python:
-  - 2.7
-  - 3.4
-  - 3.5
-  - 3.6
-
+- 2.7
+- 3.4
+- 3.5
+- 3.6
 before_install:
-  - pip install --quiet coverage flake8 pyyaml
-
+- pip install --quiet coverage flake8 pyyaml
 install:
-  - make install
-
+- make install
 script:
-  - make test
-
+- make test
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
-
+- bash <(curl -s https://codecov.io/bash)
 sudo: false
+env:
+  global:
+  - secure: F4114AVsajBPgK2lhGA+oKUwICiq50ziJk7USgT587GRCXR3rt/ERdOzZd2lBfmb6i2jR6YKcZ1/W4qp5D7EC1qyOgfXUQbKFuJ00JsMD3C/PJXQWQxtaBfhFOaKxXPzpKKo2oJhkC2kqTpC6ch6gjMCupUoAgJZd7KVRS4pkkxSNF9FhObl6etUfod76XHnPKfMCzZQGVkLJsg1i5dbiwKz5TsCBfXcVb0xgFE0MgwmAuIkrou0RH+Ag/XMNEY8NFRd0Nuf3hC4CJ07K9U/rlfkxDuRHN8otd3dMAoZV8ZPO87wPgvJ+S62BKvWXQd2f0CzqTCrQsS9tJoHyQvfz8lVGpYd8+Qywfw7Ao6k+lGEm6bmeZjPQ0Pnk/s3AD255fCsBKaA9bVUQ423vwmiebYM/5sHCsThtqx61gJyjojFDmN5rFgPtdOlVJXU3ka20jpsa/wCyys9TzdaHvM7Q8NWkwfk090+WqgWLlvwsAIqpoZLm1ZwVm66V51Z1el+/zaw05BDoRrNFIaP1oV3dYyb8aki/fWSLcQ2DSP54a1SZkUCiiD/mOxalZZdG4yRL3wRV6bSKeWppt/dX0SHXmPEPWW930YVaLz5peCsHcB3Zvd7IOAGUWs7wCRAq26lYruvi6cqD3UtHJl+/ghv+oy/Hgpk2x8rcVKIlvMuD5A=
+  - secure: i4TnnjYv1u6ujWBNCZiO82uu1Ooti/Savgti+c5cCsWg1zus5QI1LMc5f16hx+NjYW4e9kWHz5nahcTFEZclm0ovx7FMLcLCHuUlaAiQhc89yqpWYR0arxBWBD0myZy0KG8PfVO/oXecKjJUQSFDUHL9OT+ELQ0Z0NYdNFiCZKzzt0Bsh+EMRcZ0r97SJHOohkGVFvX2NeKGvkcOVyxd20H7xMKTG+2Sx5IEMj8BI6EPrZ1yPjJ4AlUjF2f5nsf5Bry9z1tZkHQn8xQeYz+e1XoGKic2qxU8utpslefWAGE5HTBydk4JwOMpACge9PUoT09/9SEu8ma01iUinMvMVNu1MbfclK6lsaohjdqaQXOdWwvjy8SltdHKG7ws9AshhnCgupM/0znLX6Gj15AFV0vCuNqUVSNfKlGt/XqwOZE+lUb8+Ej9DPqnFNSAGU2RSFDEmrVu1OWkA1dz5cJ6R09+C6jFAuP4YKn3YB3S2LJ/iIqvx2SW3O8j0q6JDVxmoPVY/CO9y37JnP5QqeQQL6xepK+/Iymd2G+gQDV2VV3LZtJnVerZPAbNL0b8tGLxJhw8aMp5lSIt+WEla6LeV+D1wnPzrw9vzAG71qmGraU2R7IO/upYuH8RPuEFWDeATWQjsa7mxwWZy45JKltlbFDH8E1GkhO/9CysNH1g9bc=
+  - AWS_DEFAULT_REGION=us-east-1

--- a/hca/upload_to_cloud.py
+++ b/hca/upload_to_cloud.py
@@ -32,7 +32,7 @@ def _mime_type(filename):
     raise RuntimeError("Can't discern mime type")
 
 
-def _copy_from_s3(path, destination_bucket, s3, tx_cfg):
+def _copy_from_s3(path, s3, tx_cfg):
     bucket_end = path.find("/", 5)
     bucket_name = path[5: bucket_end]
     dir_path = path[bucket_end + 1:]
@@ -67,14 +67,14 @@ def upload_to_cloud(files, staging_bucket, replica, from_cloud=False):
     tx_cfg = TransferConfig(multipart_threshold=S3Etag.etag_stride,
                             multipart_chunksize=S3Etag.etag_stride)
     s3 = boto3.resource("s3")
-    destination_bucket = s3.Bucket(staging_bucket)
     file_uuids = []
     key_names = []
 
     if from_cloud:
-        file_uuids, key_names = _copy_from_s3(files[0], destination_bucket, s3, tx_cfg)
+        file_uuids, key_names = _copy_from_s3(files[0], s3, tx_cfg)
 
     else:
+        destination_bucket = s3.Bucket(staging_bucket)
         for raw_fh in files:
             with ChecksummingBufferedReader(raw_fh) as fh:
                 file_uuid = str(uuid.uuid4())

--- a/hca/upload_to_cloud.py
+++ b/hca/upload_to_cloud.py
@@ -48,17 +48,19 @@ def _copy_from_s3(path, destination_bucket, s3, tx_cfg):
         logging.info(dest_key)
         copy_source = {
             'Bucket': src_bucket.name,
-            'Key': obj.key}
-        print(copy_source)
-        s3.meta.client.copy(
-            copy_source,
-            destination_bucket.name,
-            dest_key,
+            'Key': obj.key
+        }
+        logging.info(copy_source)
+        s3.meta.client.copy_object(
+            CopySource=copy_source,
+            Bucket=destination_bucket.name,
+            Key=dest_key,
+            TaggingDirective='COPY'
             # Config=tx_cfg,
             # ExtraArgs={"MetadataDirective": "COPY"}
         )
         key_names.append(dest_key)
-    print(key_names)
+    logging.info(key_names)
     return key_names
 
 

--- a/hca/upload_to_cloud.py
+++ b/hca/upload_to_cloud.py
@@ -40,15 +40,17 @@ def _copy_from_s3(path, destination_bucket, s3, tx_cfg):
     src_bucket = s3.Bucket(bucket_name)
     file_uuids = []
     key_names = []
+    logging.info("Key Names:")
     for obj in src_bucket.objects.filter(Prefix=dir_path):
         # Empty files with no name were throwing errors
         if obj.key == dir_path:
             continue
 
+        logging.info(obj.key)
+
         file_uuids.append(str(uuid.uuid4()))
         key_names.append(obj.key)
 
-    logging.info(key_names)
     return file_uuids, key_names
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,9 @@ setup(
     author_email='akislyuk@chanzuckerberg.com',
     description='Human Cell Atlas Data Storage System Command Line Interface',
     long_description=open('README.rst').read(),
+    tests_require=[
+        "six==1.10.0"
+    ],
     install_requires=[
         "requests==2.17.3",
         "jsonpointer==1.10",

--- a/test/test.py
+++ b/test/test.py
@@ -230,6 +230,21 @@ class TestHCACLI(unittest.TestCase):
         out = {"query": {"hello": "world", "goodbye": "earth"}}
         self.assertEqual(out, parsed_args)
 
+    def test_upload_to_cloud_from_s3(self):
+        uuids, names = hca.upload_to_cloud.upload_to_cloud(
+            ["s3://hca-dss-test-src/data-bundles-examples/import/10x/pbmc8k/bundles/bundle1/"],
+            "pointless-staging-bucket",
+            "aws",
+            True
+        )
+        out = [
+            "data-bundles-examples/import/10x/pbmc8k/bundles/bundle1/assay.json",
+            "data-bundles-examples/import/10x/pbmc8k/bundles/bundle1/project.json",
+            "data-bundles-examples/import/10x/pbmc8k/bundles/bundle1/sample.json"
+        ]
+        self.assertEqual(len(uuids), len(names))
+        self.assertItemsEqual(names, out)
+
     def test_upload_files(self):
         pass
 

--- a/test/test.py
+++ b/test/test.py
@@ -8,6 +8,8 @@ import sys
 import unittest
 import pprint
 
+import six
+
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, pkg_root)
 
@@ -243,7 +245,9 @@ class TestHCACLI(unittest.TestCase):
             "data-bundles-examples/import/10x/pbmc8k/bundles/bundle1/sample.json"
         ]
         self.assertEqual(len(uuids), len(names))
-        self.assertItemsEqual(names, out)
+        assert_list_items_equal = (self.assertCountEqual if six.PY3
+                                   else self.assertItemsEqual)
+        assert_list_items_equal(names, out)
 
     def test_upload_files(self):
         pass


### PR DESCRIPTION
Now supports the command `hca upload s3://my-remote-bucket/fastqs/bundle`.
All files within the bundle must have all required checksums precomputed. These are: 
* sha1
* sha256
* crc32c
* s3_etag
* content-type