### PR TITLE
Stream print & print bytes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ lint:
 hca/api_spec.json:
 	curl https://hca-dss.czi.technology/v1/swagger.json > hca/api_spec.json
 
-test: lint bindings
+test: lint install
 	pip install six coverage
 	coverage run --source=$$(python setup.py --name) ./test/test.py
 

--- a/hca/__init__.py
+++ b/hca/__init__.py
@@ -26,17 +26,13 @@ def main():
     if isinstance(response, requests.Response):
         for chunk in response.iter_content(chunk_size=Constants.CHUNK_SIZE, decode_unicode=True):
             if chunk:  # filter out keep-alive new chunks
-                _write_binary_to_stdout(chunk)
+                if six.PY3:
+                    sys.stdout.buffer.write(chunk)
+                else:
+                    sys.stdout.write(chunk)  
     elif isinstance(response, dict):
         print(json.dumps(response))
     elif isinstance(response, str):
         print(response)
     else:  # Unicode
         print(response.decode())
-
-
-def _write_binary_to_stdout(content):
-    if six.PY3:
-        sys.stdout.buffer.write(content)
-    else:
-        sys.stdout.write(content)

--- a/hca/__init__.py
+++ b/hca/__init__.py
@@ -16,7 +16,10 @@ def main():
     response = cli.make_request(sys.argv[1:])
 
     if isinstance(response, requests.Response):
-        print(response.content.decode())
+        CHUNK_SIZE = (2 ** 20) * 16  # 16 MB
+        for chunk in response.iter_content(chunk_size=CHUNK_SIZE, decode_unicode=True):
+            if chunk:  # filter out keep-alive new chunks
+                print(chunk)
     elif isinstance(response, dict):
         print(json.dumps(response))
     elif isinstance(response, str):

--- a/hca/__init__.py
+++ b/hca/__init__.py
@@ -29,7 +29,7 @@ def main():
                 if six.PY3:
                     sys.stdout.buffer.write(chunk)
                 else:
-                    sys.stdout.write(chunk)  
+                    sys.stdout.write(chunk)
     elif isinstance(response, dict):
         print(json.dumps(response))
     elif isinstance(response, str):

--- a/hca/__init__.py
+++ b/hca/__init__.py
@@ -6,7 +6,7 @@ import json
 import requests
 import sys
 
-import six
+from .constants import Constants
 
 
 def main():
@@ -16,10 +16,12 @@ def main():
     response = cli.make_request(sys.argv[1:])
 
     if isinstance(response, requests.Response):
-        CHUNK_SIZE = (2 ** 20) * 16  # 16 MB
-        for chunk in response.iter_content(chunk_size=CHUNK_SIZE, decode_unicode=True):
+        for chunk in response.iter_content(chunk_size=Constants.CHUNK_SIZE, decode_unicode=True):
             if chunk:  # filter out keep-alive new chunks
-                print(chunk)
+                try:
+                    print(chunk.decode())
+                except UnicodeDecodeError:
+                    print(chunk)
     elif isinstance(response, dict):
         print(json.dumps(response))
     elif isinstance(response, str):

--- a/hca/__init__.py
+++ b/hca/__init__.py
@@ -16,8 +16,13 @@ def main():
     """Entrance to functionality."""
     from .cli import CLI
     cli = CLI()
-    response = cli.make_request(sys.argv[1:])
 
+    # Windows includes carriage returns
+    if sys.platform == 'win32':
+        import msvcrt
+        msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
+
+    response = cli.make_request(sys.argv[1:])
     if isinstance(response, requests.Response):
         for chunk in response.iter_content(chunk_size=Constants.CHUNK_SIZE, decode_unicode=True):
             if chunk:  # filter out keep-alive new chunks
@@ -34,9 +39,4 @@ def _write_binary_to_stdout(content):
     if six.PY3:
         sys.stdout.buffer.write(content)
     else:
-        # Windows includes carriage returns
-        if sys.platform == 'win32':
-            import msvcrt
-            msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
-
         sys.stdout.write(content)

--- a/hca/added_command.py
+++ b/hca/added_command.py
@@ -377,7 +377,7 @@ class AddedCommand(object):
             'params': query_payload,
             'headers': header_payload,
             'json': body_payload if method in json_methods else None,
-            'stream': args.get('stream', False)
+            'stream': args.get('stream', True)  # Default to stream
         }
 
         requires_auth = cls._get_endpoint_info().get('requires_auth', False)

--- a/hca/constants.py
+++ b/hca/constants.py
@@ -15,3 +15,4 @@ class Constants:
     OBJECT_SPLITTER = "/"
     TWEAK_PROJECT_NAME = "hca"
     APPLICATION_SECRETS_ENDPOINT = "https://hca-dss.czi.technology/internal/application_secrets"
+    CHUNK_SIZE = (2 ** 20) * 16  # 16 MB

--- a/test/test.py
+++ b/test/test.py
@@ -23,6 +23,8 @@ from hca import regenerate_api  # noqa
 from hca import constants  # noqa
 from test.config import override_oauth_config  # noqa
 
+dirpath = os.path.dirname(os.path.realpath(__file__))
+
 
 class TestHCACLI(unittest.TestCase):
     """Test the entire module."""
@@ -158,6 +160,25 @@ class TestHCACLI(unittest.TestCase):
                     'hierarchy': ['bundle_uuid']
             }}}
         )
+
+    def test_get_files_cli(self):
+        """Testing 2 things: 1. Printing bytes to stdout; 2. Iterative content download."""
+        import subprocess
+
+        file_path = os.path.join(dirpath, "bundle", "SRR2967608_1.fastq.gz")
+
+        self.assertGreater(os.stat(file_path).st_size, constants.Constants.CHUNK_SIZE)
+
+        args = {'file_or_dir': [file_path],
+                'replica': "aws",
+                'staging_bucket': "org-humancellatlas-dss-cli-test"}
+        response = api.upload(**args)
+
+        file_uuid = response['files'][0]['uuid']
+
+        process = subprocess.Popen(["hca", "get-files", file_uuid, "--replica", "aws"], stdout=subprocess.PIPE)
+        out, _ = process.communicate()
+        self.assertIsInstance(out, bytes)
 
     def test_parsing(self):
         """Test that the parser parses arguments correctly."""

--- a/test/test.py
+++ b/test/test.py
@@ -23,8 +23,6 @@ from hca import regenerate_api  # noqa
 from hca import constants  # noqa
 from test.config import override_oauth_config  # noqa
 
-dirpath = os.path.dirname(os.path.realpath(__file__))
-
 
 class TestHCACLI(unittest.TestCase):
     """Test the entire module."""
@@ -165,6 +163,7 @@ class TestHCACLI(unittest.TestCase):
         """Testing 2 things: 1. Printing bytes to stdout; 2. Iterative content download."""
         import subprocess
 
+        dirpath = os.path.dirname(os.path.realpath(__file__))
         file_path = os.path.join(dirpath, "bundle", "SRR2967608_1.fastq.gz")
 
         self.assertGreater(os.stat(file_path).st_size, constants.Constants.CHUNK_SIZE)

--- a/test/test.py
+++ b/test/test.py
@@ -11,6 +11,7 @@ import unittest
 import uuid
 import pprint
 from six.moves import reload_module
+from io import open
 
 import requests
 import six
@@ -178,6 +179,9 @@ class TestHCACLI(unittest.TestCase):
         process = subprocess.Popen(["hca", "get-files", file_uuid, "--replica", "aws"], stdout=subprocess.PIPE)
         out, _ = process.communicate()
         self.assertIsInstance(out, bytes)
+        with open(file_path, "rb") as bytes_fh:
+            file_content = bytes_fh.read()
+        self.assertEqual(file_content, out)
 
     def test_parsing(self):
         """Test that the parser parses arguments correctly."""


### PR DESCRIPTION
* This handles data formats that the cli previously didn't decode (specifically gzip). 
* Also handles the case where you call get-files on an enormous file. Streams the content instead of loading it immediately. 
* Changes the `make test` target to include install, which pip installs the package and puts hca into the namespace. I couldn't think of another way to check that the output printed bytes - open to other suggestions if you think this is a bad solution. 