### PR TITLE
Fix spin loop so it detects real errors.

### DIFF
--- a/hca/dss/composite_commands/upload.py
+++ b/hca/dss/composite_commands/upload.py
@@ -160,8 +160,12 @@ class Upload(AddedCommand):
                         get_resp = hca.dss.head_files(file_uuid, version)
                         if get_resp.ok:
                             break
-                        time.sleep(wait)
-                        wait = min(60.0, wait * Upload.BACKOFF_FACTOR)
+                        elif get_resp.status_code == requests.codes.not_found:
+                            time.sleep(wait)
+                            wait = min(60.0, wait * Upload.BACKOFF_FACTOR)
+                        else:
+                            raise RuntimeError(
+                                "File {}: Unexpected server response during registration".format(filename))
                     else:
                         # timed out. :(
                         raise RuntimeError("File {}: registration FAILED".format(filename))


### PR DESCRIPTION
When we're waiting for the async upload, we should only expect 200 (found) or 404 (not-found).  Any other error code should be considered an error.